### PR TITLE
Exiting with non-zero status on error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ if [[ -z $GITHUB_BASE_REF ]]; then
   exit 0;
 fi
 
-curl -sf -o ./formatter.js https://raw.githubusercontent.com/reviewdog/action-eslint/master/eslint-formatter-rdjson/index.js 
+curl -sf -o ./formatter.js https://raw.githubusercontent.com/reviewdog/action-eslint/master/eslint-formatter-rdjson/index.js
 
 ESLINT_FORMATTER="./formatter.js"
 GITHUB_TOKEN=$INPUT_TOKEN
@@ -140,9 +140,9 @@ else
 
       if [[ $exit_status -ne 0 ]]; then
         echo "::warning::Error running eslint."
-        exit 0;
+        exit 1;
       fi
-      
+
       git remote remove temp_eslint_changed_files
     fi
   else


### PR DESCRIPTION
We must exit with a non-zero status code to ensure builds fail.

Fixes #397