### PR TITLE
Introduce ignore_config_path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,3 +91,13 @@ jobs:
             **/*.tsx
           extra_args: "--max-warnings=0"
           all_files: true
+
+      - name: Run ESLint without --config flag
+        uses: ./
+        with:
+          ignore_config_path: true
+          file_extensions: |
+            **/*.ts
+            **/*.tsx
+          extra_args: "--max-warnings=0"
+          all_files: true

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: '[ESlint](https://eslint.org/) [configuration file](https://eslint.org/docs/user-guide/configuring/)'
     required: false
     default: '.eslintrc'
+  ignore_config_path:
+    description: 'Run [ESlint](https://eslint.org/) without --config flag, helpful when you have nested folders with .eslintrc files'
+    required: false
+    default: false
   ignore_path:
     description: '[ESlint](https://eslint.org/) [ignore file](https://eslint.org/docs/user-guide/configuring/ignoring-code)'
     required: false
@@ -93,6 +97,7 @@ runs:
         INPUT_ALL_FILES: ${{ inputs.all_files }}
         INPUT_CONFIG_PATH: ${{ inputs.config_path }}
         INPUT_IGNORE_PATH: ${{ inputs.ignore_path }}
+        INPUT_IGNORE_CONFIG_PATH: ${{ inputs.ignore_config_path }}
         INPUT_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         INPUT_EXTRA_ARGS: ${{ inputs.extra_args }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,23 +23,26 @@ ESLINT_FORMATTER="./formatter.cjs"
 
 # shellcheck disable=SC2034
 export REVIEWDOG_GITHUB_API_TOKEN=$INPUT_TOKEN
-CONFIG_PATH=$INPUT_CONFIG_PATH
 IGNORE_PATH=$INPUT_IGNORE_PATH
 EXTRA_ARGS=$INPUT_EXTRA_ARGS
+CONFIG_ARG="--config=${INPUT_CONFIG_PATH}"
 
+if [[ "$INPUT_IGNORE_CONFIG_PATH" == "true" ]]; then
+  CONFIG_ARG=""
+fi
 
 if [[ "$INPUT_ALL_FILES" == "true" ]]; then
   if [[ "$INPUT_SKIP_ANNOTATIONS" == "true" ]]; then
     if [[ -n ${IGNORE_PATH} ]]; then
       # shellcheck disable=SC2086
-      npx eslint --config="${CONFIG_PATH}" --ignore-path="${IGNORE_PATH}" ${EXTRA_ARGS} && exit_status=$? || exit_status=$?
+      npx eslint ${CONFIG_ARG} --ignore-path="${IGNORE_PATH}" ${EXTRA_ARGS} && exit_status=$? || exit_status=$?
     else
       # shellcheck disable=SC2086
-      npx eslint --config="${CONFIG_PATH}" ${EXTRA_ARGS} && exit_status=$? || exit_status=$?
+      npx eslint ${CONFIG_ARG} ${EXTRA_ARGS} && exit_status=$? || exit_status=$?
     fi
   elif [[ -n ${IGNORE_PATH} ]]; then
     # shellcheck disable=SC2086
-    npx eslint --config="${CONFIG_PATH}" --ignore-path="${IGNORE_PATH}" ${EXTRA_ARGS} -f="${ESLINT_FORMATTER}" . | reviewdog -f=rdjson \
+    npx eslint ${CONFIG_ARG} --ignore-path="${IGNORE_PATH}" ${EXTRA_ARGS} -f="${ESLINT_FORMATTER}" . | reviewdog -f=rdjson \
       -name=eslint \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
@@ -47,7 +50,7 @@ if [[ "$INPUT_ALL_FILES" == "true" ]]; then
       -level="${INPUT_LEVEL}" && exit_status=$? || exit_status=$?
   else
     # shellcheck disable=SC2086
-    npx eslint --config="${CONFIG_PATH}" ${EXTRA_ARGS} -f="${ESLINT_FORMATTER}" . | reviewdog -f=rdjson \
+    npx eslint ${CONFIG_ARG} ${EXTRA_ARGS} -f="${ESLINT_FORMATTER}" . | reviewdog -f=rdjson \
       -name=eslint \
       -reporter="${INPUT_REPORTER}" \
       -filter-mode="${INPUT_FILTER_MODE}" \
@@ -66,14 +69,14 @@ else
       if [[ "$INPUT_SKIP_ANNOTATIONS" == "true" ]]; then
         if [[ -n ${IGNORE_PATH} ]]; then
           # shellcheck disable=SC2086
-          npx eslint --config="${CONFIG_PATH}" --ignore-path="${IGNORE_PATH}" ${EXTRA_ARGS} ${INPUT_CHANGED_FILES} && exit_status=$? || exit_status=$?
+          npx eslint ${CONFIG_ARG} --ignore-path="${IGNORE_PATH}" ${EXTRA_ARGS} ${INPUT_CHANGED_FILES} && exit_status=$? || exit_status=$?
         else
           # shellcheck disable=SC2086
-          npx eslint --config="${CONFIG_PATH}" ${EXTRA_ARGS} ${INPUT_CHANGED_FILES} && exit_status=$? || exit_status=$?
+          npx eslint ${CONFIG_ARG} ${EXTRA_ARGS} ${INPUT_CHANGED_FILES} && exit_status=$? || exit_status=$?
         fi
       elif [[ -n ${IGNORE_PATH} ]]; then
         # shellcheck disable=SC2086
-        npx eslint --config="${CONFIG_PATH}" --ignore-path="${IGNORE_PATH}" ${EXTRA_ARGS} -f="${ESLINT_FORMATTER}" ${INPUT_CHANGED_FILES} | reviewdog -f=rdjson \
+        npx eslint ${CONFIG_ARG} --ignore-path="${IGNORE_PATH}" ${EXTRA_ARGS} -f="${ESLINT_FORMATTER}" ${INPUT_CHANGED_FILES} | reviewdog -f=rdjson \
           -name=eslint \
           -reporter="${INPUT_REPORTER}" \
           -filter-mode="${INPUT_FILTER_MODE}" \
@@ -81,7 +84,7 @@ else
           -level="${INPUT_LEVEL}" && exit_status=$? || exit_status=$?
       else
         # shellcheck disable=SC2086
-        npx eslint --config="${CONFIG_PATH}" ${EXTRA_ARGS} -f="${ESLINT_FORMATTER}" ${INPUT_CHANGED_FILES} | reviewdog -f=rdjson \
+        npx eslint ${CONFIG_ARG} ${EXTRA_ARGS} -f="${ESLINT_FORMATTER}" ${INPUT_CHANGED_FILES} | reviewdog -f=rdjson \
           -name=eslint \
           -reporter="${INPUT_REPORTER}" \
           -filter-mode="${INPUT_FILTER_MODE}" \


### PR DESCRIPTION
# Description
The problem that I want to solve is having the option to ignore passing the`--config` flag to ESLint.
If you pass the `--config` flag to ESLint you can't have [configuration cascading.](https://eslint.org/docs/latest/user-guide/configuring/configuration-files#cascading-and-hierarchy)



For example:
```
monorepo
├── .eslintrc <--- root: true
├── react-project
│ └── source.js
└─┬ vue-project
  ├── .eslintrc <--- can have different parser or rules...
  └── file.js
  ```