### PR TITLE
enhancement(inputs): Accept `skip_initial_fetch` and pass to Changed-Files Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ Support this project with a :star:
     # Default: "${{ github.token }}"
     token: ''
 
+    # Skip fetching more histories when repo is shallow, this is passed to the [Changed Files Action](https://github.com/tj-actions/changed-files)
+    # Type: boolean
+    # Default: false
+    skip_initial_fetch: ''
+
 ```
 
 <!-- AUTO-DOC-INPUT:END -->

--- a/README.md
+++ b/README.md
@@ -138,11 +138,6 @@ Support this project with a :star:
     # Default: "${{ github.token }}"
     token: ''
 
-    # Skip fetching more histories when repo is shallow, this is passed to the [Changed Files Action](https://github.com/tj-actions/changed-files)
-    # Type: boolean
-    # Default: false
-    skip_initial_fetch: ''
-
 ```
 
 <!-- AUTO-DOC-INPUT:END -->

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ inputs:
    description: "Relative path under GITHUB_WORKSPACE to the repository"
    required: false
    default: '.'
+  skip_initial_fetch:
+    desciption: "Skip fetching more histories when the repo is shallow, this is passed to [Changed Files](https://github.com/codesculpture/changed-files)" 
+    required: false
+    default: false
 
 runs:
   using: 'composite'
@@ -72,6 +76,7 @@ runs:
         files: ${{ inputs.file_extensions }}
         files_ignore_from_source_file: ${{ inputs.ignore_path }}
         diff_relative: true
+        skip_initial_fetch: ${{ inputs.skip_initial_fetch }}
     - name: Run eslint on changed files
       run: |
         # Run eslint on changed files

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ inputs:
    required: false
    default: '.'
   skip_initial_fetch:
-    desciption: "Skip fetching more histories when the repo is shallow, this is passed to [Changed Files](https://github.com/codesculpture/changed-files)" 
+    description: "Skip fetching more histories when the repo is shallow, this is passed to [Changed Files](https://github.com/codesculpture/changed-files)" 
     required: false
     default: false
 

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,9 @@ inputs:
    required: false
    default: '.'
   skip_initial_fetch:
-    description: "Skip fetching more histories when the repo is shallow, this is passed to [Changed Files](https://github.com/tj-actions/changed-files)" 
+    description: |
+      Skip initially fetching additional history to improve performance for shallow repositories.
+      NOTE: This could lead to errors with missing history. It's intended to be used when you've fetched all necessary history to perform the diff.
     required: false
     default: false
 

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ inputs:
    required: false
    default: '.'
   skip_initial_fetch:
-    description: "Skip fetching more histories when the repo is shallow, this is passed to [Changed Files](https://github.com/codesculpture/changed-files)" 
+    description: "Skip fetching more histories when the repo is shallow, this is passed to [Changed Files](https://github.com/tj-actions/changed-files)" 
     required: false
     default: false
 


### PR DESCRIPTION
In some cases, we don't need to let this action fetch history this has been controlled through input in [Changed Files Action](https://github.com/tj-actions/changed-files) . So now requesting to pass the input from here to [Changed Files Action](https://github.com/tj-actions/changed-files).