### PR TITLE
feat(INFRA-1459): Stale GH actions workflow and README update

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,15 @@
+---
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: [self-hosted, runner, mgmt, base]
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label, comment on PR or this will be closed in 10 days.'
+          days-before-stale: 30
+          days-before-close: 10

--- a/README.md
+++ b/README.md
@@ -122,3 +122,10 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+\n## Stale PRs
+
+Stale pull requests (PRs) are those that have not had any activity for a certain period of time. It's important to manage stale PRs to keep the project's pull requests manageable and to ensure that contributions are either moving forward or being closed if they are no longer relevant.
+
+Stale PRs are managed by using the [Stale](https://github.com/actions/stale):
+- PRs with no activity for 30 days are marked as stale
+- stale PRs for 10 days are closed


### PR DESCRIPTION
## Jira Task link

Link to [INFRA-1459](https://cloudtalk.atlassian.net/browse/INFRA-1459)

## Why is this change required

Configure [Stale](https://github.com/actions/stale) to firstly mark PRs as stale after 30 days of inactivity and then close them after 10 days of being stale.

## What changed

- Added a new workflow file `stale.yaml` to `.github/workflows` directory.
- updated docs